### PR TITLE
2023-07-19 Rishideep surfaceDestroyed bug fix

### DIFF
--- a/app/src/main/java/com/example/iris/login1/GalleryActivity.java
+++ b/app/src/main/java/com/example/iris/login1/GalleryActivity.java
@@ -3003,15 +3003,26 @@ public class GalleryActivity extends AppCompatActivity implements SurfaceHolder.
         // the "holder" is get in oncreat() at the beginning
         surfaceHolder = holder;
         // 录像线程，当然也可以在别的地方启动，但是一定要在onCreate方法执行完成以及surfaceHolder被赋值以后启动
+
+        if (thread != null && thread.mPlayer != null) {
+            thread.mPlayer.setDisplay(surfaceHolder);
+        }
     }
 
     @Override
     public void surfaceDestroyed(SurfaceHolder arg0) {
         // TODO Auto-generated method stub
         Log.i("SurfaceHolder", "surfaceDestroyed()");
+
+        if (thread != null && thread.mPlayer != null) {
+            thread.mPlayer.stop();
+            thread.mPlayer.release();
+            thread.mPlayer = null;
+        }
         //release the resources
-/*        surfaceview = null;
-        surfaceHolder = null;*/
+        // surfaceview = null;
+        surfaceHolder = null;
+        
         /* mediarecorder mCamera */
         if (thread!=null) {
             thread.stopRecord();


### PR DESCRIPTION
* released mPlayer & RecordThread resources before calling the stopRecord() method to stop the thread gracefully

* calling setDisplay(surfaceHolder) inside surfaceCreated for already existing MediaPlayer mPlayer setup in "RecordThread.java" file

* changes made should ensure the surface is not released or destroyed abruptly